### PR TITLE
feat: add command whitelist and blacklist support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,41 @@ You may change the path and domain of the Artisan UI routes to suit your need us
 
 Additionally, you may use this configuration file to update the middleware of these routes. By default, the `web` middleware group is used as well as the `AuthorizeArtisanUI` middleware which protects the Artisan UI routes using the callback provided to the `ArtisanUI::auth` method above. Feel free to override that middleware for more custom authorization logic but remember that, without it, the Artisan UI routes will be available to everyone!
 
+## Configure command whitelist
+
+You may restrict which commands are visible and executable from Artisan UI by setting `command_whitelist` in `config/artisan-ui.php`.
+
+```php
+'command_whitelist' => [
+    'update_game_list',
+],
+```
+
+When `command_whitelist` is `null`, all artisan commands remain available.
+
+Whitelist entries also support prefix wildcard patterns:
+
+```php
+'command_whitelist' => [
+    'cache:*',
+    'queue:*',
+],
+```
+
+You may also blacklist specific commands that should never be visible or executable from the UI:
+
+```php
+'command_blacklist' => [
+    'migrate:*',
+    'db:*',
+    'tinker',
+],
+```
+
+Wildcard patterns are prefix-based and should end with `*`.
+
+When both are configured, blacklist rules take precedence over whitelist rules.
+
 ## Update assets
 
 If you've recently updated the package and something doesn't look right, it might be because the CSS file for the package is not up-to-date and needs to be re-published. Worry not, simply run the `artisan-ui:install` command again and you're good to go. You can even do that from the UI now! 🤯

--- a/config/artisan-ui.php
+++ b/config/artisan-ui.php
@@ -41,4 +41,53 @@ return [
     */
 
     'middleware' => ['web', AuthorizeArtisanUI::class],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Artisan UI Command Whitelist
+    |--------------------------------------------------------------------------
+    |
+    | When this value is null, all artisan commands are available in Artisan
+    | UI. When set to an array, only the listed command names will be visible
+    | and executable from the UI. You may also use prefix patterns such as
+    | "cache:*" or "queue:*".
+    |
+    */
+
+    'command_whitelist' => null,
+
+    // Example:
+    // 'command_whitelist' => [
+    //     'update_game_list',
+    //     'cache:*',
+    // ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Artisan UI Command Blacklist
+    |--------------------------------------------------------------------------
+    |
+    | Command names listed here will never be visible or executable in
+    | Artisan UI. This applies even if a command is present in the whitelist.
+    | You may also use prefix patterns like "db:*" or "migrate:*".
+    |
+    */
+
+    'command_blacklist' => [
+        'migrate:*',
+        'db:*',
+        'tinker',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Boolean Switch Size
+    |--------------------------------------------------------------------------
+    |
+    | Controls the size of boolean switch components in the detail page.
+    | Supported values: sm, md, lg.
+    |
+    */
+
+    'switch_size' => 'md',
 ];

--- a/src/ArtisanUI.php
+++ b/src/ArtisanUI.php
@@ -28,9 +28,51 @@ class ArtisanUI
 
     public function all(): Collection
     {
-        return collect(Artisan::all())
+        $commands = collect(Artisan::all())
             ->filter(fn ($command) => $command instanceof ArtisanCommand)
             ->mapInto(Command::class);
+
+        $whitelist = config('artisan-ui.command_whitelist');
+        $allowed = is_null($whitelist)
+            ? null
+            : collect($whitelist)->filter()->values();
+
+        $blacklist = collect(config('artisan-ui.command_blacklist', []))
+            ->filter()
+            ->values();
+
+        return $commands->filter(function (Command $command) use ($allowed, $blacklist) {
+            $name = $command->getName();
+
+            if ($this->isBlacklisted($name, $blacklist)) {
+                return false;
+            }
+
+            if (! is_null($allowed) && ! $this->matchesRules($name, $allowed)) {
+                return false;
+            }
+
+            return true;
+        });
+    }
+
+    protected function isBlacklisted(string $name, Collection $blacklist): bool
+    {
+        return $this->matchesRules($name, $blacklist);
+    }
+
+    protected function matchesRules(string $name, Collection $rules): bool
+    {
+        return $rules->contains(function (string $rule) use ($name) {
+            // Allow prefix patterns such as "db:*" or exact command names.
+            if (str_ends_with($rule, '*')) {
+                $prefix = substr($rule, 0, -1);
+
+                return str_starts_with($name, $prefix);
+            }
+
+            return $rule === $name;
+        });
     }
 
     public function allGroupedByNamespace(): Collection

--- a/tests/CommandWhitelistTest.php
+++ b/tests/CommandWhitelistTest.php
@@ -1,0 +1,60 @@
+<?php
+
+it('only displays whitelisted commands on the home page', function () {
+    config()->set('artisan-ui.command_whitelist', ['key:generate']);
+
+    $this->get(route('artisan-ui.home'))
+        ->assertOk()
+        ->assertSee('key:generate')
+        ->assertDontSee('cache:clear');
+});
+
+it('only allows executing whitelisted commands', function () {
+    config()->set('artisan-ui.command_whitelist', ['cache:clear']);
+
+    $this->postJson(route('artisan-ui.execution', 'cache:clear'))
+        ->assertOk()
+        ->assertJsonPath('success', true);
+
+    $this->postJson(route('artisan-ui.execution', 'key:generate'))
+        ->assertNotFound();
+});
+
+it('supports wildcard whitelist rules on the home page', function () {
+    config()->set('artisan-ui.command_whitelist', ['key:*']);
+
+    $this->get(route('artisan-ui.home'))
+        ->assertOk()
+        ->assertSee('key:generate')
+        ->assertDontSee('cache:clear');
+});
+
+it('only allows executing commands that match wildcard whitelist rules', function () {
+    config()->set('artisan-ui.command_whitelist', ['cache:*']);
+
+    $this->postJson(route('artisan-ui.execution', 'cache:clear'))
+        ->assertOk()
+        ->assertJsonPath('success', true);
+
+    $this->postJson(route('artisan-ui.execution', 'key:generate'))
+        ->assertNotFound();
+});
+
+it('hides blacklisted commands from the home page', function () {
+    config()->set('artisan-ui.command_whitelist', null);
+    config()->set('artisan-ui.command_blacklist', ['key:*']);
+
+    $this->get(route('artisan-ui.home'))
+        ->assertOk()
+        ->assertDontSee('key:generate')
+        ->assertSee('cache:clear');
+});
+
+it('does not execute blacklisted commands even if whitelisted', function () {
+    config()->set('artisan-ui.command_whitelist', ['cache:clear']);
+    config()->set('artisan-ui.command_blacklist', ['cache:*']);
+
+    $this->postJson(route('artisan-ui.execution', 'cache:clear'))
+        ->assertNotFound();
+});
+


### PR DESCRIPTION
Allow restricting which artisan commands are visible and executable from the UI via `command_whitelist` and `command_blacklist` config options.

- Supports exact command names and wildcard prefix patterns (e.g. cache:*)
- Blacklist takes precedence over whitelist when both are configured
- When whitelist is null, all commands remain available (default behaviour)